### PR TITLE
ci: run pages workflow on pull requests

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches: ["main"]
 
+  # Runs on pull requests targeting the default branch
+  pull_request:
+    branches: ["main"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -79,6 +83,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -83,7 +83,6 @@ jobs:
 
   # Deployment job
   deploy:
-    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -93,3 +92,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          preview: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches: ["main"]
 
-  # Pull requests deploy a preview instead of the production site
+  # Pull requests run checks but skip deployment
   pull_request:
     branches: ["main"]
 
@@ -83,6 +83,8 @@ jobs:
 
   # Deployment job
   deploy:
+    # Skip deployment for pull-request events since Pages only has one environment
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -92,6 +94,4 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        with:
-          # PRs deploy preview environments; pushes and manual runs go to production
-          preview: ${{ github.event_name == 'pull_request' }}
+

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -2,15 +2,15 @@
 name: Deploy Hugo site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Production deployments on pushes to the default branch
   push:
     branches: ["main"]
 
-  # Runs on pull requests targeting the default branch
+  # Pull requests deploy a preview instead of the production site
   pull_request:
     branches: ["main"]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Manual trigger for production deployments from the Actions tab
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -93,4 +93,5 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
         with:
+          # PRs deploy preview environments; pushes and manual runs go to production
           preview: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary
- trigger Pages workflow for pull requests to main
- skip deployment step when workflow runs for pull_request events

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6897694e18b08333b48e988a22af3661