### PR TITLE
fix: correct edit URL for site

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -40,4 +40,4 @@ params:
 
   editURL:
     enable: true
-    base: "https://github.com/amineamanzou/practical-otel-otca-journey/edit/main/content"
+    base: "https://github.com/amineamanzou/practical-opentelemetry-otca/edit/main/content"


### PR DESCRIPTION
## Summary
- correct `editURL` base link in Hugo config

## Testing
- `hugo --config hugo.yaml -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689767a4385083339782c4a84fc9970b