### PR TITLE
ci: add codespell check to pages workflow

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -45,6 +45,16 @@ jobs:
         run: npm install -g markdownlint-cli
       - name: Run markdownlint
         run: markdownlint content/**/*.md
+  # Spellcheck job
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install codespell
+        run: pip install codespell
+      - name: Run codespell
+        run: codespell content
   # Build job
   build:
     runs-on: ubuntu-latest

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "The Certification Domains "
 weight: 1
-description: "Lerning more about the domains covered by the opentelemetry certification."
+description: "Learning more about the domains covered by the OpenTelemetry certification."
 ---
 
 The OTCA certification covers four main knowledge domains:


### PR DESCRIPTION
## Summary
- run codespell on content directory via new `spellcheck` job

## Testing
- `codespell content` *(fails: content/docs/_index.md:4: Lerning ==> Learning, Leaning)*
- `markdownlint content/**/*.md`


------
https://chatgpt.com/codex/tasks/task_e_6897c8ad55608333b373943a4ceabb43